### PR TITLE
Updated migration tables

### DIFF
--- a/project-anemone/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/project-anemone/database/migrations/2014_10_12_000000_create_users_table.php
@@ -19,7 +19,6 @@ return new class extends Migration
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
-            $table->rememberToken();
             $table->timestamps();
         });
     }

--- a/project-anemone/database/migrations/2022_03_14_022342_add_documents_table.php
+++ b/project-anemone/database/migrations/2022_03_14_022342_add_documents_table.php
@@ -19,11 +19,11 @@ return new class extends Migration
             $table->timestamps();
             $table->unsignedBigInteger('user_id');
             $table->foreign('user_id')->references('id')->on('users');
-            $table->text('path');
+            $table->text('path')->nullable();
             $table->text('name');
-            $table->text('project_id')->nullable();
             $table->text('file_type')->nullable();
             $table->text('url')->nullable();
+            $table->text('url_data')->nullable();
         });
     }
 


### PR DESCRIPTION
Removed remember tokens and project_id columns, and added back in the file_metadata column to store scraped data.